### PR TITLE
Fix module name

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,6 @@ Fixes # (issue)
 
 ### Quick checks:
 
-- [ ] There is no other [pull request](https://github.com/alarbada/conduit-connector-activemq-artemis/pulls) for the same update/change.
+- [ ] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-activemq-artemis/pulls) for the same update/change.
 - [ ] I have written unit tests.
 - [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,7 +7,7 @@ builds:
     env:
       - CGO_ENABLED=0
     ldflags:
-      - "-s -w -X 'github.com/alarbada/conduit-connector-activemq-artemis.version={{ .Tag }}'"
+      - "-s -w -X 'github.com/conduitio-labs/conduit-connector-activemq-artemis.version={{ .Tag }}'"
 checksum:
   name_template: checksums.txt
 archives:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ VERSION=$(shell git describe --tags --dirty --always)
 
 .PHONY: build
 build:
-	go build -ldflags "-X 'github.com/alarbada/conduit-connector-activemq-artemis.version=${VERSION}'" -o conduit-connector-activemq-artemis cmd/connector/main.go
+	go build -ldflags "-X 'github.com/conduitio-labs/conduit-connector-activemq-artemis.version=${VERSION}'" -o conduit-connector-activemq-artemis cmd/connector/main.go
 
 .PHONY: test
 test: up

--- a/cmd/connector/main.go
+++ b/cmd/connector/main.go
@@ -15,7 +15,7 @@
 package main
 
 import (
-	activemq "github.com/alarbada/conduit-connector-activemq-artemis"
+	activemq "github.com/conduitio-labs/conduit-connector-activemq-artemis"
 	sdk "github.com/conduitio/conduit-connector-sdk"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/alarbada/conduit-connector-activemq-artemis
+module github.com/conduitio-labs/conduit-connector-activemq-artemis
 
 go 1.24.2
 

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,4 +1,4 @@
-module github.com/alarbada/conduit-connector-activemq-artemis/tools
+module github.com/conduitio-labs/conduit-connector-activemq-artemis/tools
 
 go 1.24.2
 


### PR DESCRIPTION
### Description

Changes the GitHub organization from alarbada to conduitio-labs.

### Quick checks:

- [ ] There is no other [pull request](https://github.com/alarbada/conduit-connector-activemq-artemis/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.